### PR TITLE
Perform Xcode recommended changes

### DIFF
--- a/Swell.xcodeproj/project.pbxproj
+++ b/Swell.xcodeproj/project.pbxproj
@@ -422,7 +422,6 @@
 		DF0A056B1954EC4800E35A15 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -442,7 +441,6 @@
 		DF0A056C1954EC4800E35A15 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
We did let Xcode `Update to recommended settings`. A warning was shown during compilation

```
Project 'Swell' - Automatically Select Architectures

Project 'Swell' overrides the Architectures setting. This will remove the settings and allow Xcode to automatically select Architectures based on hardware available for the active platform and deployment target.
```
