### PR TITLE
Fix Issue #4: Function in Formatter contains Optional()

### DIFF
--- a/Swell/Formatter.swift
+++ b/Swell/Formatter.swift
@@ -153,8 +153,8 @@ public class FlexFormatter: LogFormatter {
                     logMessage += "[\(filename!.lastPathComponent):\(line!)]"
                 }
             case .FUNC:
-                if (function != nil) {
-                    logMessage += "[\(function)()]"
+                if let function = function {
+                    logMessage += "[\(function)]"
                 }
             }
             

--- a/SwellTests/SwellTests.swift
+++ b/SwellTests/SwellTests.swift
@@ -350,6 +350,12 @@ class SwellTests: XCTestCase {
         println("Formatter \(formatter.description())")
     }
     
+    func testFlexFormatterOptionalFunction() {
+        let flex = FlexFormatter(parts: .FUNC, .MESSAGE)
+        let logger = Logger(name:"test", formatter: flex)
+        let message = flex.formatLog(logger, level: .INFO, message: "my message", filename: nil, line: nil, function: __FUNCTION__)
+        XCTAssertEqual(message, "[testFlexFormatterOptionalFunction()]: my message")
+    }
     
     func testFlexPerformance() {
         // This is an example of a performance test case.


### PR DESCRIPTION
Fixed Issue #4: Function in Formatter contains Optional()
## Cause

The function name string as String? was not unwrapped to String before it was used in a string format.
## Fix

Added an optional binding to the function parameter.
