### PR TITLE
Updated for Swift 1.2:

### DIFF
--- a/Swell/Formatter.swift
+++ b/Swell/Formatter.swift
@@ -11,11 +11,11 @@
 public protocol LogFormatter {
     
     /// Formats the message provided for the given logger
-    func formatLog<T>(logger: Logger, level: LogLevel, message: @autoclosure() -> T,
+    func formatLog<T>(logger: Logger, level: LogLevel, @autoclosure message: () -> T,
                       filename: String?, line: Int?,  function: String?) -> String;
     
     /// Returns an instance of this class given a configuration string
-    class func logFormatterForString(formatString: String) -> LogFormatter;
+    static func logFormatterForString(formatString: String) -> LogFormatter;
     
     /// Returns a string useful for describing this class and how it is configured
     func description() -> String;
@@ -45,7 +45,7 @@ public class QuickFormatter: LogFormatter {
         self.format = format
     }
     
-    public func formatLog<T>(logger: Logger, level: LogLevel, message givenMessage: @autoclosure() -> T,
+    public func formatLog<T>(logger: Logger, level: LogLevel, @autoclosure message givenMessage: () -> T,
                              filename: String?, line: Int?,  function: String?) -> String {
         var s: String;
         let message = givenMessage()
@@ -137,7 +137,7 @@ public class FlexFormatter: LogFormatter {
     }
     
 
-    public func formatLog<T>(logger: Logger, level: LogLevel, message givenMessage: @autoclosure() -> T,
+    public func formatLog<T>(logger: Logger, level: LogLevel, @autoclosure message givenMessage: () -> T,
                              filename: String?, line: Int?,  function: String?) -> String {
         var logMessage = ""
         for (index, part) in enumerate(format) {

--- a/Swell/LogLocation.swift
+++ b/Swell/LogLocation.swift
@@ -10,7 +10,7 @@ import Foundation
 public protocol LogLocation {
     //class func getInstance(param: AnyObject? = nil) -> LogLocation
 
-    func log(message: @autoclosure() -> String);
+    func log(@autoclosure message: () -> String);
     
     func enable();
     
@@ -36,7 +36,7 @@ public class ConsoleLocation: LogLocation {
         return instance
     }
 
-    public func log(message: @autoclosure() -> String) {
+    public func log(@autoclosure message: () -> String) {
         if enabled {
             println(message())
         }
@@ -86,7 +86,7 @@ public class FileLocation: LogLocation {
         closeFile()
     }
     
-    public func log(message: @autoclosure() -> String) {
+    public func log(@autoclosure message: () -> String) {
         //message.writeToFile(filename, atomically: false, encoding: NSUTF8StringEncoding, error: nil);
         if (!enabled) {
             return

--- a/Swell/LogSelector.swift
+++ b/Swell/LogSelector.swift
@@ -96,7 +96,7 @@ public class LogSelector {
         let temp = string.componentsSeparatedByString(",")
         for s: String in temp {
             // 'countElements(s)' returns s.length
-            if (countElements(s) > 0) {
+            if (count(s) > 0) {
                 result.append(s)
             }
             //if (s.lengthOfBytesUsingEncoding(NSUTF8StringEncoding) > 0) {

--- a/Swell/Logger.swift
+++ b/Swell/Logger.swift
@@ -33,7 +33,7 @@ public class Logger {
     
     
     public func log<T>(logLevel: LogLevel,
-                        message: @autoclosure() -> T,
+                        @autoclosure message: () -> T,
                         filename: String? = __FILE__, line: Int? = __LINE__,  function: String? = __FUNCTION__) {
         if (self.enabled) && (logLevel.level >= level.level) {
             let logMessage = formatter.formatLog(self, level: logLevel, message: message,
@@ -48,32 +48,32 @@ public class Logger {
     //**********************************************************************
     // Main log methods
     
-    public func trace<T>(message: @autoclosure() -> T,
+    public func trace<T>(@autoclosure message: () -> T,
                          filename: String? = __FILE__, line: Int? = __LINE__,  function: String? = __FUNCTION__) {
         self.log(.TRACE, message: message, filename: filename, line: line, function: function)
     }
     
-    public func debug<T>(message: @autoclosure() -> T,
+    public func debug<T>(@autoclosure message: () -> T,
                          filename: String? = __FILE__, line: Int? = __LINE__,  function: String? = __FUNCTION__) {
         self.log(.DEBUG, message: message, filename: filename, line: line, function: function)
     }
     
-    public func info<T>(message: @autoclosure() -> T,
+    public func info<T>(@autoclosure message: () -> T,
                         filename: String? = __FILE__, line: Int? = __LINE__,  function: String? = __FUNCTION__) {
         self.log(.INFO, message: message, filename: filename, line: line, function: function)
     }
     
-    public func warn<T>(message: @autoclosure() -> T,
+    public func warn<T>(@autoclosure message: () -> T,
                         filename: String? = __FILE__, line: Int? = __LINE__,  function: String? = __FUNCTION__) {
         self.log(.WARN, message: message, filename: filename, line: line, function: function)
     }
     
-    public func error<T>(message: @autoclosure() -> T,
+    public func error<T>(@autoclosure message: () -> T,
                          filename: String? = __FILE__, line: Int? = __LINE__,  function: String? = __FUNCTION__) {
         self.log(.ERROR, message: message, filename: filename, line: line, function: function)
     }
     
-    public func severe<T>(message: @autoclosure() -> T,
+    public func severe<T>(@autoclosure message: () -> T,
                           filename: String? = __FILE__, line: Int? = __LINE__,  function: String? = __FUNCTION__) {
         self.log(.SEVERE, message: message, filename: filename, line: line, function: function)
     }

--- a/Swell/Swell.swift
+++ b/Swell/Swell.swift
@@ -70,42 +70,42 @@ public class Swell {
     //========================================================================================
     // Global/convenience log methods used for quick logging
 
-    public class func trace<T>(message: @autoclosure() -> T) {
+    public class func trace<T>(@autoclosure message: () -> T) {
         if globalSwell.swellLogger == nil {
             globalSwell.initInternalLogger()
         }
         globalSwell.swellLogger.trace(message)
     }
     
-    public class func debug<T>(message: @autoclosure() -> T) {
+    public class func debug<T>(@autoclosure message: () -> T) {
         if globalSwell.swellLogger == nil {
             globalSwell.initInternalLogger()
         }
         globalSwell.swellLogger.debug(message)
     }
     
-    public class func info<T>(message: @autoclosure() -> T) {
+    public class func info<T>(@autoclosure message: () -> T) {
         if globalSwell.swellLogger == nil {
             globalSwell.initInternalLogger()
         }
         globalSwell.swellLogger.info(message)
     }
     
-    public class func warn<T>(message: @autoclosure() -> T) {
+    public class func warn<T>(@autoclosure message: () -> T) {
         if globalSwell.swellLogger == nil {
             globalSwell.initInternalLogger()
         }
         globalSwell.swellLogger.warn(message)
     }
     
-    public class func error<T>(message: @autoclosure() -> T) {
+    public class func error<T>(@autoclosure message: () -> T) {
         if globalSwell.swellLogger == nil {
             globalSwell.initInternalLogger()
         }
         globalSwell.swellLogger.error(message)
     }
     
-    public class func severe<T>(message: @autoclosure() -> T) {
+    public class func severe<T>(@autoclosure message: () -> T) {
         if globalSwell.swellLogger == nil {
             globalSwell.initInternalLogger()
         }
@@ -552,7 +552,7 @@ public class Swell {
     func getFunctionFormat(function: String) -> String {
         var result = function;
         if (result.hasPrefix("Optional(")) {
-            let len = countElements("Optional(")
+            let len = count("Optional(")
             let start = advance(result.startIndex, len)
             let end = advance(result.endIndex, -len)
             let range = start..<end


### PR DESCRIPTION
```
message: @autoclosure() 
```

becomes

```
@autoclosure message: ()
```

and

```
countElements() 
```

becomes

```
count()
```
